### PR TITLE
Add start method to worker

### DIFF
--- a/benchmarks/krewtest.js
+++ b/benchmarks/krewtest.js
@@ -69,3 +69,5 @@ worker.on("ready", function() {
 worker.on("error", function(err) {
   console.error("Worker encountered error:", err);
 });
+
+worker.start();

--- a/examples/krewtest.js
+++ b/examples/krewtest.js
@@ -46,3 +46,5 @@ worker.on("ready", function() {
 worker.on("error", function(err) {
   console.error("Worker encountered error:", err);
 });
+
+worker.start();

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -5,6 +5,7 @@ var Transport = require("kimbu").Transport;
 var Client = require("kimbu").Client;
 var util = require("util");
 var assert = require("assert");
+var Promise = require("bluebird");
 
 /**
  * Emitted when the worker is ready for sending events. The event takes no arguments.
@@ -92,23 +93,20 @@ function Worker(workerName, transport, messages) {
 
   var self = this;
 
+  var deferred = Promise.pending();
+
   this._client = new Client(workerName, transport, function(err) {
     /* istanbul ignore if */
     if (err) {
-      self.emit("error", err);
+      deferred.reject(err);
     } else {
       self._messages = messages;
       self._registerMessages(messages);
-      self._client.start(function(err) {
-        /* istanbul ignore if */
-        if (err) {
-          self.emit("error", err);
-        } else {
-          self.emit("ready");
-        }
-      });
+      deferred.resolve();
     }
   });
+
+  this._connectionPromise = deferred.promise;
 
   //TODO: catch messagebus disconnected event
 }
@@ -178,6 +176,39 @@ Worker.prototype.request = function(cmd, parameters, options, callback) {
  */
 Worker.prototype.publish = function(event, parameters, options, callback) {
   this._client.publish(event, parameters, options, callback);
+};
+
+/**
+ * Starts the worker. Once started the worker will receive messages and will be able to
+ * send messages itself.
+ * Emits `ready` when started successfully or `error` when an error occurred.
+ *
+ * @param {Function} [callback] - Optional callback called when stop() has finished.
+ *
+ * @emits ready
+ * @emits error
+ * @public
+ */
+Worker.prototype.start = function(callback) {
+  assert(util.isNullOrUndefined(callback) | util.isFunction(callback));
+  var self = this;
+
+  this._connectionPromise.then(function() {
+    self._client.start(function(err) {
+      /* istanbul ignore if */
+      if (err) {
+        self.emit("error", err);
+      } else {
+        self.emit("ready");
+      }
+      if (callback) {
+        setImmediate(callback.bind(self, err));
+      }
+    });
+  }, /* istanbul ignore next */
+    function(err) {
+    self.emit("error");
+  });
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "node >=0.11.0"
   ],
   "dependencies": {
+    "bluebird": "^2.10.1",
     "kimbu": "0.x"
   },
   "devDependencies": {


### PR DESCRIPTION
The worker does not start automatically anymore from within its constructor.
Instead, the worker must be started explicitly. This is better balanced with the
stop method.
